### PR TITLE
内测质押流动性限制改为最大 625 万

### DIFF
--- a/src/components/Stake/StakeLiquidityPanel.tsx
+++ b/src/components/Stake/StakeLiquidityPanel.tsx
@@ -551,14 +551,14 @@ const StakeLiquidityPanel: React.FC<StakeLiquidityPanelProps> = ({}) => {
             )}
           />
 
-          {govVotes && govVotes >= 22207680000000000000000n && (
+          {govVotes && govVotes >= 22207670000000000000000n && (
             <div className="flex justify-center space-x-2 mt-4">
               <Button type="button" className="w" disabled={true}>
                 第1次内测体验, 暂时关闭追加治理票
               </Button>
             </div>
           )}
-          {(!govVotes || govVotes < 22207680000000000000000n) && (
+          {(!govVotes || govVotes < 22207670000000000000000n) && (
             <div className="flex justify-center space-x-2 mt-4">
               <Button
                 type="button"


### PR DESCRIPTION
[内测质押流动性限制改为最大 625 万](https://github.com/LOVE20TKM/interface/commit/1012de72301262ee11b104b06dbd4171178a3122)